### PR TITLE
Avoid creating unneeded ALB rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 all: container
 
 TAG?=v1.1.5
-PREFIX?=amazon/aws-alb-ingress-controller
+PREFIX?=peopleperhour/aws-alb-ingress-controller
 ARCH?=amd64
 OS?=linux
 PKG=github.com/kubernetes-sigs/aws-alb-ingress-controller
@@ -26,6 +26,8 @@ REPO_INFO=$(shell git config --get remote.origin.url)
 GO111MODULE=on
 GOPROXY=direct
 GOBIN:=$(shell pwd)/.bin
+CHECKSUM=$(shell cat *.* internal/alb/ls/* | md5sum | cut -c1-8)
+
 
 .EXPORT_ALL_VARIABLES:
 
@@ -43,6 +45,15 @@ container:
 
 push:
 	docker push $(PREFIX):$(TAG)
+	@echo "The CHECKSUM of all files in this folder is ${CHECKSUM}."
+	docker tag ${PREFIX}:$(TAG) ${PREFIX}:${TAG}_${CHECKSUM}
+	docker push ${PREFIX}:${TAG}_${CHECKSUM}
+
+push-test:
+	@echo "The CHECKSUM of all files in this folder is ${CHECKSUM}."
+	@echo "Pushing to Docker Hub..."
+	docker tag ${PREFIX}:$(TAG) ${PREFIX}:${TAG}_${CHECKSUM}
+	docker push ${PREFIX}:${TAG}_${CHECKSUM}
 
 clean:
 	rm -f server

--- a/internal/alb/ls/rules_test.go
+++ b/internal/alb/ls/rules_test.go
@@ -2878,6 +2878,102 @@ func Test_createsRedirectLoop(t *testing.T) {
 	}
 }
 
+func Test_isUnconditionalRedirect(t *testing.T) {
+    for _, tc := range []struct {
+        name     string
+        listener elbv2.Listener
+        rule     elbv2.Rule
+
+        expected bool
+    }{
+        {
+            name:     "No RedirectConfig",
+            listener: elbv2.Listener{Protocol: aws.String("HTTP"), Port: aws.Int64(80)},
+            rule:     elbv2.Rule{},
+            expected: false,
+        },
+        {
+            name:     "Path condition set to /*",
+            listener: elbv2.Listener{Protocol: aws.String("HTTP"), Port: aws.Int64(80)},
+            rule: elbv2.Rule{
+                Actions: []*elbv2.Action{
+                    {
+                        Type:           aws.String(elbv2.ActionTypeEnumRedirect),
+                        RedirectConfig: redirectActionConfig(&elbv2.RedirectActionConfig{Path: aws.String("/#{path}")}),
+                    },
+                },
+                Conditions: []*elbv2.RuleCondition{
+                    {
+                        Field: aws.String(conditions.FieldPathPattern),
+                        PathPatternConfig: &elbv2.PathPatternConditionConfig{
+                            Values: aws.StringSlice([]string{"/*"}),
+                        },
+                    },
+                },
+            },
+            expected: true,
+        },
+        {
+            name:     "Path condition set to /* and Host condition is set ",
+            listener: elbv2.Listener{Protocol: aws.String("HTTP"), Port: aws.Int64(80)},
+            rule: elbv2.Rule{
+                Actions: []*elbv2.Action{
+                    {
+                        Type:           aws.String(elbv2.ActionTypeEnumRedirect),
+                        RedirectConfig: redirectActionConfig(&elbv2.RedirectActionConfig{Path: aws.String("/#{path}")}),
+                    },
+                },
+                Conditions: []*elbv2.RuleCondition{
+                    {
+                        Field: aws.String(conditions.FieldPathPattern),
+                        PathPatternConfig: &elbv2.PathPatternConditionConfig{
+                            Values: aws.StringSlice([]string{"/*"}),
+                        },
+                    },
+                    {
+                        Field: aws.String(conditions.FieldHostHeader),
+                        HostHeaderConfig: &elbv2.HostHeaderConditionConfig{
+                            Values: aws.StringSlice([]string{"www.example.com", "anno.example.com"}),
+                        },
+                    },
+                },
+            },
+            expected: true,
+        },
+        {
+            name:     "Path condition set to /* but a SourceIP condition is also set",
+            listener: elbv2.Listener{Protocol: aws.String("HTTP"), Port: aws.Int64(80)},
+            rule: elbv2.Rule{
+                Actions: []*elbv2.Action{
+                    {
+                        Type:           aws.String(elbv2.ActionTypeEnumRedirect),
+                        RedirectConfig: redirectActionConfig(&elbv2.RedirectActionConfig{Path: aws.String("/#{path}")}),
+                    },
+                },
+                Conditions: []*elbv2.RuleCondition{
+                    {
+                        Field: aws.String(conditions.FieldPathPattern),
+                        PathPatternConfig: &elbv2.PathPatternConditionConfig{
+                            Values: aws.StringSlice([]string{"/*"}),
+                        },
+                    },
+                    {
+                        Field: aws.String(conditions.FieldSourceIP),
+                        SourceIpConfig: &elbv2.SourceIpConditionConfig{
+                            Values: aws.StringSlice([]string{"192.168.0.0/16"}),
+                        },
+                    },
+                },
+            },
+            expected: false,
+        },
+    } {
+        t.Run(tc.name, func(t *testing.T) {
+            assert.Equal(t, tc.expected, isUnconditionalRedirect(&tc.listener, tc.rule))
+        })
+    }
+}
+
 func redirectActionConfig(override *elbv2.RedirectActionConfig) *elbv2.RedirectActionConfig {
 	r := &elbv2.RedirectActionConfig{
 		Host:       aws.String("#{host}"),


### PR DESCRIPTION
ALBs only support 100 rules - it is therefore important to avoid adding unneeded rules.

If a unconditional redirect rule is present in the configuration then all following rules within the same listener are not needed. This PR changes things so they are skipped thereby conserving rules.

---

Resources:

* Relevant upstream code section: https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/internal/alb/ls/rules.go#L147
* Relvant GitHub issue https://github.com/kubernetes-sigs/aws-alb-ingress-controller/issues/853#issuecomment-578547468 -  This is where I found out about the special annotation for redirects:
https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/docs/guide/tasks/ssl_redirect.md
* Trello: https://trello.com/c/swBdRRe1
